### PR TITLE
Fixes #9 by providing a simple implementation for GenOperation::isOve…

### DIFF
--- a/plugins/org.eclipse.uml2.codegen.ecore/src/org/eclipse/uml2/codegen/ecore/genmodel/impl/GenOperationImpl.java
+++ b/plugins/org.eclipse.uml2.codegen.ecore/src/org/eclipse/uml2/codegen/ecore/genmodel/impl/GenOperationImpl.java
@@ -408,6 +408,17 @@ public class GenOperationImpl
 	public boolean isOverrideOf(
 			org.eclipse.emf.codegen.ecore.genmodel.GenClass genClass,
 			org.eclipse.emf.codegen.ecore.genmodel.GenOperation genOperation) {
+		// only redefined operations can override
+		if (!isRedefinition()) {
+			return false;
+		}
+		
+		// search in redefined operations
+		List<org.eclipse.emf.codegen.ecore.genmodel.GenOperation> redefinedOperations = getRedefinedGenOperations();
+		if (redefinedOperations.contains(genOperation))
+			return true;
+		
+		// nothing to override found
 		return false;
 	}
 


### PR DESCRIPTION
proposed fix does the following:
1. only if UML redefined operation is set for an operation then an operation can override another -> potential match
2. tries to find the operation in question in the list of redefined operations -> match or not
3. otherwise "fails" by returning false