### PR TITLE
Update UML2.setup

### DIFF
--- a/releng/org.eclipse.uml2.build-feature/UML2.setup
+++ b/releng/org.eclipse.uml2.build-feature/UML2.setup
@@ -17,7 +17,7 @@
       source="http://www.eclipse.org/oomph/setup/BrandingInfo">
     <detail
         key="imageURI">
-      <value>https://git.eclipse.org/c/emf/org.eclipse.emf.git/plain/plugins/org.eclipse.emf/modeling32.png</value>
+      <value>https://raw.githubusercontent.com/eclipse-emf/org.eclipse.emf/master/plugins/org.eclipse.emf/modeling32.png</value>
     </detail>
     <detail
         key="siteURI">


### PR DESCRIPTION
Use the modeling32.png image from EMF's github repository

Currently I have nasty code like this in Oomph's SetupArchiver to deal with this very last reference to git.eclipse.org in the overall setup index:

![image](https://github.com/user-attachments/assets/5f0bfc59-f9f3-4fae-b57c-1dcb2c68a4df)

I did that because https://git.eclipse.org/c has become extremely unreliable.  So ideally this would be changes in the setup and I could remove that nasty code.



