### PR TITLE
Removes method that is already available in UML2Util

### DIFF
--- a/plugins/org.eclipse.uml2.uml/src/org/eclipse/uml2/uml/internal/operations/ElementOperations.java
+++ b/plugins/org.eclipse.uml2.uml/src/org/eclipse/uml2/uml/internal/operations/ElementOperations.java
@@ -1760,13 +1760,6 @@ public class ElementOperations
 		EcoreUtil.remove(ancestorEObject);
 	}
 
-	protected static void destroyAll(Collection<EObject> eObjects) {
-
-		for (Iterator<EObject> o = eObjects.iterator(); o.hasNext();) {
-			destroy(o.next());
-		}
-	}
-
 	protected static EList<Element> allOwnedElements(Element element,
 			EList<Element> allOwnedElements) {
 


### PR DESCRIPTION
For another follow-up PR I had to compile everything briefly with a later Java Version and it complains that the exact same method already exists in the class hierarchy. And in fact it does in UML2Util, with the same signature and code. Thus this method can be removed.