### PR TITLE
Missing Import Statement  causing ClassNotFound outside of Eclipse

### DIFF
--- a/plugins/org.eclipse.uml2.uml/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.uml2.uml/META-INF/MANIFEST.MF
@@ -14,6 +14,8 @@ Export-Package: org.eclipse.uml2.uml,
  org.eclipse.uml2.uml.internal.resource;x-internal:=true,
  org.eclipse.uml2.uml.resource,
  org.eclipse.uml2.uml.util
+Import-Package: org.xml.sax,
+  org.xml.sax.helpers
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)";resolution:=optional;x-installation:=greedy,
  org.eclipse.emf.ecore;bundle-version="[2.16.0,3.0.0)";visibility:=reexport,
  org.eclipse.emf.ecore.xmi;bundle-version="[2.15.0,3.0.0)";visibility:=reexport,


### PR DESCRIPTION
When running in OSGi, but outside of Eclipse, the missing import statement cause ClassNotFound Exceptions, when an XMI is parsed